### PR TITLE
SUS024 RH social holding/maintenance page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,21 +10,21 @@
     <title>Page unavailable - My Study</title>
     <meta content="" name="description">
     <meta content="width=device-width, initial-scale=1" name="viewport">    
-    <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.ons.gov.uk/v1.7.0/favicons/apple-touch-icon.png">
-    <link rel="icon" type="image/png" href="https://cdn.ons.gov.uk/v1.7.0/favicons/favicon-32x32.png" sizes="32x32">
-    <link rel="icon" type="image/png" href="https://cdn.ons.gov.uk/v1.7.0/favicons/favicon-16x16.png" sizes="16x16">
-    <link rel="manifest" href="https://cdn.ons.gov.uk/v1.7.0/favicons/manifest.json">
-    <link rel="mask-icon" href="https://cdn.ons.gov.uk/v1.7.0/favicons/safari-pinned-tab.svg" color="#5bbad5">
-    <link rel="shortcut icon" href="https://cdn.ons.gov.uk/v1.7.0/favicons/favicon.ico" >
+    <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.ons.gov.uk/sdc/v1.7.0/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="https://cdn.ons.gov.uk/sdc/v1.7.0/favicons/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="https://cdn.ons.gov.uk/sdc/v1.7.0/favicons/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="https://cdn.ons.gov.uk/sdc/v1.7.0/favicons/manifest.json">
+    <link rel="mask-icon" href="https://cdn.ons.gov.uk/sdc/v1.7.0/favicons/safari-pinned-tab.svg" color="#5bbad5">
+    <link rel="shortcut icon" href="https://cdn.ons.gov.uk/sdc/v1.7.0/favicons/favicon.ico" >
     <meta name="theme-color" content="#ffffff">
     <!--[if lt IE 9]>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
     <!--[if (gt IE 9) | (IEMobile)]><!-->
-      <link href="https://cdn.ons.gov.uk/v1.7.0/sdc/css/responsive.css" rel="stylesheet" />
+      <link href="https://cdn.ons.gov.uk/sdc/v1.7.0/css/responsive.css" rel="stylesheet" />
     <!--<![endif]-->
     <!--[if (lte IE 9) & (!IEMobile)]>
-      <link href="https://cdn.ons.gov.uk/v1.7.0/sdc/css/fixed.css" rel="stylesheet" />
+      <link href="https://cdn.ons.gov.uk/sdc/v1.7.0/css/fixed.css" rel="stylesheet" />
     <![endif]-->
   </head>
 
@@ -44,7 +44,7 @@
                   <div class="grid__col col-6@s">
                     <div class="logo">
                       <a href="https://surveys.onsdigital.uk/mystudy/">
-                        <img src="https://cdn.ons.gov.uk/v1.7.0/sdc/img/ons-logo-pos.svg" alt="Office for National Statistics logo" class="logo__img header__logo">
+                        <img src="https://cdn.ons.gov.uk/sdc/v1.7.0/img/ons-logo-pos.svg" alt="Office for National Statistics logo" class="logo__img header__logo">
                       </a>
                     </div>
                   </div>
@@ -131,7 +131,7 @@
 
                 <div class="grid__col col-12@m">
                   <div class="footer__license footer__license--border">
-                    <img alt="OGL" class="footer__ogl-img" src="https://cdn.ons.gov.uk/v1.7.0/img/UKOpenGovernmentLicence-grey.svg"> All content is available under the <a class="footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a>, except where otherwise stated
+                    <img alt="OGL" class="footer__ogl-img" src="https://cdn.ons.gov.uk/sdc/v1.7.0/img/UKOpenGovernmentLicence-grey.svg"> All content is available under the <a class="footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a>, except where otherwise stated
                   </div>
                 </div>
               </div>

--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,4 @@
 <!doctype html>
-{% set cdn_hash = "v1.7.0" %}
-{% set cdn_url_prefix = "https://cdn.ons.gov.uk/sdc/"~cdn_hash %}
 <!--[if lt IE 7]>      <html lang="en-gb" dir="ltr" class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html lang="en-gb" dir="ltr" class="no-js lt-ie10 lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html lang="en-gb" dir="ltr" class="no-js lt-ie10 lt-ie9"> <![endif]-->
@@ -12,23 +10,21 @@
     <title>Page unavailable - My Study</title>
     <meta content="" name="description">
     <meta content="width=device-width, initial-scale=1" name="viewport">    
-    <link rel="apple-touch-icon" sizes="180x180" href="{{ cdn_url_prefix }}/favicons/apple-touch-icon.png">
-    <link rel="icon" type="image/png" href="{{ cdn_url_prefix }}/favicons/favicon-32x32.png" sizes="32x32">
-    <link rel="icon" type="image/png" href="{{ cdn_url_prefix }}/favicons/favicon-16x16.png" sizes="16x16">
-    <link rel="manifest" href="{{ cdn_url_prefix }}/favicons/manifest.json">
-    <link rel="mask-icon" href="{{ cdn_url_prefix }}/favicons/safari-pinned-tab.svg" color="#5bbad5">
-    <link rel="shortcut icon" href="{{ cdn_url_prefix }}/favicons/favicon.ico" >
+    <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.ons.gov.uk/v1.7.0/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="https://cdn.ons.gov.uk/v1.7.0/favicons/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="https://cdn.ons.gov.uk/v1.7.0/favicons/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="https://cdn.ons.gov.uk/v1.7.0/favicons/manifest.json">
+    <link rel="mask-icon" href="https://cdn.ons.gov.uk/v1.7.0/favicons/safari-pinned-tab.svg" color="#5bbad5">
+    <link rel="shortcut icon" href="https://cdn.ons.gov.uk/v1.7.0/favicons/favicon.ico" >
     <meta name="theme-color" content="#ffffff">
     <!--[if lt IE 9]>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
-    {% set css_fixed_cdn = cdn_url_prefix~"/css/fixed.css" %}
-    {% set css_responsive_cdn = cdn_url_prefix~"/css/responsive.css" %}
     <!--[if (gt IE 9) | (IEMobile)]><!-->
-      <link href="{{ css_responsive_cdn }}" rel="stylesheet" />
+      <link href="https://cdn.ons.gov.uk/v1.7.0/sdc/css/responsive.css" rel="stylesheet" />
     <!--<![endif]-->
     <!--[if (lte IE 9) & (!IEMobile)]>
-      <link href="{{ css_fixed_cdn }}" rel="stylesheet" />
+      <link href="https://cdn.ons.gov.uk/v1.7.0/sdc/css/fixed.css" rel="stylesheet" />
     <![endif]-->
   </head>
 
@@ -48,8 +44,7 @@
                   <div class="grid__col col-6@s">
                     <div class="logo">
                       <a href="https://surveys.onsdigital.uk/mystudy/">
-                        {% set logo_cdn = cdn_url_prefix~"/img/ons-logo-pos.svg" %}
-                        <img src="{{ logo_cdn }}" alt="Office for National Statistics logo" class="logo__img header__logo">
+                        <img src="https://cdn.ons.gov.uk/v1.7.0/sdc/img/ons-logo-pos.svg" alt="Office for National Statistics logo" class="logo__img header__logo">
                       </a>
                     </div>
                   </div>
@@ -76,7 +71,7 @@
                 </h1>
                     
                 <p>We're undergoing planned maintenance. </p>
-                <p>Sorry for the inconvenience.</p>
+                <p>We apologise for any inconvenience this may cause.</p>
                 <p>Please try again later, or <a href="https://surveys.onsdigital.uk/mystudy/contact-us">contact us</a> to speak to a member of our team.</p>
               </div>
             </div>
@@ -136,8 +131,7 @@
 
                 <div class="grid__col col-12@m">
                   <div class="footer__license footer__license--border">
-                    {% set logo_cdn = cdn_url_prefix~"/img/UKOpenGovernmentLicence-grey.svg" %}
-                    <img alt="OGL" class="footer__ogl-img" src="{{ logo_cdn }}"> All content is available under the <a class="footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a>, except where otherwise stated
+                    <img alt="OGL" class="footer__ogl-img" src="https://cdn.ons.gov.uk/v1.7.0/img/UKOpenGovernmentLicence-grey.svg"> All content is available under the <a class="footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a>, except where otherwise stated
                   </div>
                 </div>
               </div>

--- a/src/index.html
+++ b/src/index.html
@@ -1,171 +1,150 @@
-<!DOCTYPE html>
-<html dir="ltr" lang="en-gb"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<!doctype html>
+{% set cdn_hash = "v1.7.0" %}
+{% set cdn_url_prefix = "https://cdn.ons.gov.uk/sdc/"~cdn_hash %}
+<!--[if lt IE 7]>      <html lang="en-gb" dir="ltr" class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html lang="en-gb" dir="ltr" class="no-js lt-ie10 lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html lang="en-gb" dir="ltr" class="no-js lt-ie10 lt-ie9"> <![endif]-->
+<!--[if IE 9]>         <html lang="en-gb" dir="ltr" class="no-js lt-ie10"> <![endif]-->
+<!--[if gt IE 9]><!--> <html lang="en-gb" dir="ltr" class="no-js"> <!--<![endif]-->
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Page unavailable - My Study</title>
+    <meta content="" name="description">
+    <meta content="width=device-width, initial-scale=1" name="viewport">    
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ cdn_url_prefix }}/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="{{ cdn_url_prefix }}/favicons/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="{{ cdn_url_prefix }}/favicons/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="{{ cdn_url_prefix }}/favicons/manifest.json">
+    <link rel="mask-icon" href="{{ cdn_url_prefix }}/favicons/safari-pinned-tab.svg" color="#5bbad5">
+    <link rel="shortcut icon" href="{{ cdn_url_prefix }}/favicons/favicon.ico" >
+    <meta name="theme-color" content="#ffffff">
+    <!--[if lt IE 9]>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
+    <![endif]-->
+    {% set css_fixed_cdn = cdn_url_prefix~"/css/fixed.css" %}
+    {% set css_responsive_cdn = cdn_url_prefix~"/css/responsive.css" %}
+    <!--[if (gt IE 9) | (IEMobile)]><!-->
+      <link href="{{ css_responsive_cdn }}" rel="stylesheet" />
+    <!--<![endif]-->
+    <!--[if (lte IE 9) & (!IEMobile)]>
+      <link href="{{ css_fixed_cdn }}" rel="stylesheet" />
+    <![endif]-->
+  </head>
 
-
-
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
-
-  <title>Service temporarily unavailable - ONS Social Surveys - Office for National Statistics (ONS)</title>
-
-  <meta name="description" content="ONS Social Surveys">
-
-  <!--[if (gt IE 9) | (IEMobile)]><!-->
-  <link rel="stylesheet" href="/assets/bres-responsive.css">
-  <!--<![endif]-->
-  <!--[if (lte IE 9) & (!IEMobile)]>
-  <link rel="stylesheet" href="/assets/bres-fixed.css?q=4a6be5362d67d24cfb7ee2f106835e1084f8f847">
-  <![endif]-->
-  <!--[endif]-->
-
-  <link rel="stylesheet" href="/assets/bres-site.css">
-  <link rel="stylesheet" href="/assets/bres-lato.css">
-  <link rel="stylesheet" href="/assets/bres-override.css">
-
-  <link href="https://surveys.onsdigital.uk/.extra/bres-favicon.ico" rel="Shortcut Icon">
-
-<style id="style-1-cropbar-clipper">/* Copyright 2014 Evernote Corporation. All rights reserved. */
-.en-markup-crop-options {
-    top: 18px !important;
-    left: 50% !important;
-    margin-left: -100px !important;
-    width: 200px !important;
-    border: 2px rgba(255,255,255,.38) solid !important;
-    border-radius: 4px !important;
-}
-
-.en-markup-crop-options div div:first-of-type {
-    margin-left: 0px !important;
-}
-</style></head>
-
-<body>
-
-  <div class="page account">
-
-    <div class="page__content">
-      <div class="skip">
-        <a class="skip__link" href="https://surveys.onsdigital.uk/.extra/bres-service-temporarily-unavailable.html#main">Skip to content</a>
-      </div>
-      <header class="page__header">
-
-        <div class="container">
-
-          <div class="header">
-
-            <div class="header__container container">
-
-              <div class="logo header__logo">
-                <img src="/assets/logo.svg" alt="Office for National Statistics" class="logo__img">
+  <body>
+    <div class="page">
+      <div class="page__content">
+        
+        <div class="skip">
+            <a class="skip__link" id="skip-link" href="#main">Skip to content</a>
+        </div>
+        
+        <div class="page__header">
+          <header class="header">
+            <div class="header__top" role="banner">
+              <div class="container">
+                <div class="grid grid--gutterless">
+                  <div class="grid__col col-6@s">
+                    <div class="logo">
+                      <a href="https://surveys.onsdigital.uk/mystudy/">
+                        {% set logo_cdn = cdn_url_prefix~"/img/ons-logo-pos.svg" %}
+                        <img src="{{ logo_cdn }}" alt="Office for National Statistics logo" class="logo__img header__logo">
+                      </a>
+                    </div>
+                  </div>
+                </div>
               </div>
-
             </div>
-
-          </div>
-
+            <div class="header__main">
+              <div class="container">
+                <div class="grid grid--gutterless grid--align-mid u-cf">
+                  <div class="grid__col col-10@xs col-6@s col-8@m">
+                    <h1 class="header__title">My Study</h1>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </header>
         </div>
-
-        <div class="bar" role="banner">
-          <div class="bar__inner container">
-            <div class="bar__title venus">ONS Social Surveys</div>
+        <div class="page__container container">
+          <div class="grid">
+            <div class="grid__col col-8@m u-mb-s">
+              <div role="main" class="page__main" id="main">
+                <h1 class="saturn">
+                  This page is temporarily unavailable
+                </h1>
+                    
+                <p>We're undergoing planned maintenance. </p>
+                <p>Sorry for the inconvenience.</p>
+                <p>Please try again later, or <a href="https://surveys.onsdigital.uk/mystudy/contact-us">contact us</a> to speak to a member of our team.</p>
+              </div>
+            </div>
           </div>
         </div>
+      </div>
 
-      </header>
-
-      <div class="page__subheader"></div>
-
-      <div class="container page__container">
-
-        <div class="grid">
-
-          <div class="grid__col col-6@m">
-            <div role="main" id="main" class="page__main">
-
-              <section>
-
-                <h1 class="saturn">Service temporarily unavailable</h1>
-
-                <div class="panel panel--simple panel--error panel--spacious">
-                  <p>This site is currently offline for maintenance.</p>
-                  <p>Sorry for any inconvenience.</p>
-                  <p>Please try again later or call us on <span class="nowrap">0300 1234 931</span> to speak with a member of our survey support team.</p>
+      <div class="page__footer">
+          <footer class="footer" role="contentinfo">
+            <div class="container">
+              <div class="grid">
+                <div class="grid__col col-4@m">
+                  <p class="venus footer__heading"><strong>Legal information</strong></p>
+                  <ul class="list list--bare">
+                    <li>
+                      <a href="https://surveys.onsdigital.uk/mystudy/cookies-privacy"
+                          class="footer__link">Cookies and privacy</a>
+                    </li>
+                  </ul>
+                </div>
+        
+                <div class="grid__col col-4@m">
+                    <p class="venus footer__heading"><strong>About ONS</strong></p>
+                    <ul class="list list--bare">
+                      <li>
+                        <a href="https://www.ons.gov.uk/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys"
+                          class="footer__link">What we do</a>
+                      </li>
+                      <li>
+                        <a href="https://surveys.onsdigital.uk/mystudy/contact-us"
+                          class="footer__link">Contact us</a>
+                      </li>
+                      <li>
+                        <a href="https://www.ons.gov.uk/help/accessibility"
+                          class="footer__link">Accessibility</a>
+                      </li>
+                    </ul>
+                </div>
+        
+                <div class="grid__col col-4@m">
+                  <p class="venus footer__heading"><strong>Statistics</strong></p>
+                  <ul class="list list--bare">
+                    <li>
+                      <a href="https://www.statisticsauthority.gov.uk/about-the-authority/"
+                        class="footer__link">UK Statistics Authority</a>
+                    </li>
+                    <li>
+                      <a href="https://www.ons.gov.uk/releasecalendar"
+                        class="footer__link">Release calendar</a>
+                    </li>
+                    <li>
+                      <a href="https://www.ons.gov.uk/news"
+                        class="footer__link">News</a>
+                    </li>
+                  </ul>
                 </div>
 
-              </section>
-
+                <div class="grid__col col-12@m">
+                  <div class="footer__license footer__license--border">
+                    {% set logo_cdn = cdn_url_prefix~"/img/UKOpenGovernmentLicence-grey.svg" %}
+                    <img alt="OGL" class="footer__ogl-img" src="{{ logo_cdn }}"> All content is available under the <a class="footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a>, except where otherwise stated
+                  </div>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-
+          </footer>
+          
       </div>
     </div>
-    <footer class="footer page__footer">
-      <div class="footer-nav container" role="contentinfo">
-
-        <div class="grid container">
-          <div class="">
-
-            <div class="grid__col col-4@m">
-              <div class="footer-nav__heading">
-                <h3 class="venus">Legal information</h3>
-              </div>
-              <ul class="footer-nav list">
-                <!--
-                <li class="footer-nav__item">
-                  <a href="" class="footer__link">Cookies and privacy</a>
-                </li>
-              -->
-                <li class="footer-nav__item">
-                  <a href="https://www.ons.gov.uk/help/termsandconditions" class="footer__link">Terms and conditions</a>
-                </li>
-              </ul>
-            </div>
-
-            <div class="grid__col col-4@m">
-              <div class="footer-nav__heading">
-                <h3 class="venus">About ONS</h3>
-              </div>
-              <ul class="footer-nav list">
-                <li class="footer-nav__item">
-                  <a href="https://www.ons.gov.uk/aboutus/whatwedo" class="footer__link">What we do</a>
-                </li>
-                <!--
-                <li class="footer-nav__item">
-                  <a href="" class="footer__link">Contact us</a>
-                </li>
-                -->
-                <li class="footer-nav__item">
-                  <a href="https://www.ons.gov.uk/help/accessibility" class="footer__link">Accessibility</a>
-                </li>
-              </ul>
-            </div>
-
-            <div class="grid__col col-4@m">
-              <div class="footer-nav__heading">
-                <h3 class="venus">Statistics</h3>
-              </div>
-              <ul class="footer-nav list">
-                <li class="footer-nav__item">
-                  <a href="https://www.statisticsauthority.gov.uk/about-the-authority/" class="footer__link">UK Statistics Authority</a>
-                </li>
-                <li class="footer-nav__item">
-                  <a href="https://www.ons.gov.uk/releasecalendar" class="footer__link">Release calendar</a>
-                </li>
-                <li class="footer-nav__item">
-                  <a href="https://www.ons.gov.uk/news">News</a>
-                </li>
-              </ul>
-            </div>
-
-          </div>
-        </div>
-
-      </div>
-    </footer>
-
-  </div>
-
-
-
-
-</body></html>
+  </body>
+</html>


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As a: A Respondent
I need: To be redirected to a holding page when the survey is made unavailable for planned maintenance
So that: I am aware of the planned unavailability

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Cloned from https://github.com/ONSdigital/ras-maintenance-page
- Updated content for social respondents

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Open `src/index.html` in a browser and check rendered content.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
![image](https://user-images.githubusercontent.com/28348457/47710160-01b24e80-dc2a-11e8-8f31-6074eec0b2fa.png)

